### PR TITLE
Dev

### DIFF
--- a/src/main/java/com/drunkendev/jdbc/h2/H2DBBackup.java
+++ b/src/main/java/com/drunkendev/jdbc/h2/H2DBBackup.java
@@ -63,21 +63,22 @@ public class H2DBBackup {
     }
 
     /**
-     * Backs up a h2 database to the home directory.
+     * Backs up a h2 database to a target directory.
      *
-     * Backup file will be stored as {@code ${app.home}/backup/app-db-backup-yyyy-MM-dd_hhmm.zip}
+     * Backup folder will first attempt to be set to a config attribute, if
+     * the attribute does not exist the location will default to home dir/backup.
+     * File name will be {@code ${app.name}-db-backup-yyyy-MM-dd_hhmm.zip}
      *
      * @throws  IOException
      *          If the backup file could not be created.
      */
     public void backupDatabase() throws IOException {
-        Path path = Paths.get(config.getHomeDir())
-                .resolve("backup")
+        Path path = config.getPathOrDefault("backup.folder", config.getHomePath().resolve("backup"))
                 .normalize();
         Path p = path
-                .resolve("app-db-backup-" + df.format(LocalDateTime.now()) + ".zip")
+                .resolve(config.getAppName() + "-db-backup-" + df.format(LocalDateTime.now()) + ".zip")
                 .normalize();
-        LOG.debug("Backing up database to {}", p);
+        LOG.info("Backing up database to {}", p);
         Files.createDirectories(path);
 
         long cut = LocalDateTime.now().minusDays(2).toEpochSecond(ZoneOffset.UTC);

--- a/src/main/java/com/drunkendev/web/settings/AppConfig.java
+++ b/src/main/java/com/drunkendev/web/settings/AppConfig.java
@@ -56,6 +56,7 @@ public class AppConfig implements InitializingBean {
     private final String configSystemEnv;
     private final String homeSystemProp;
     private final String homeSystemEnv;
+    private final String homeConfigProp;
 
     private Properties props;
     private final ClassLoader loader;
@@ -83,6 +84,7 @@ public class AppConfig implements InitializingBean {
         configSystemEnv = appNameUc + "_CONFIG";
         homeSystemProp = appNameLc + ".home";
         homeSystemEnv = appNameUc + "_HOME";
+        homeConfigProp = appNameLc + ".home";
         this.loader = loader == null ? AppConfig.class.getClassLoader() : loader;
         LOG.debug("APP NAME: " + appName);
     }
@@ -136,6 +138,7 @@ public class AppConfig implements InitializingBean {
      * This will check int he following order for
      *
      * <ul>
+     *  <li>{@code app.home} config file property</li>
      *  <li>{@code app.home} system property</li>
      *  <li>{@code APP_HOME} environment variable</li>
      *  <li>{@code user.dir} system property</li>
@@ -151,20 +154,24 @@ public class AppConfig implements InitializingBean {
             return homeDir;
         }
 
-        String path = System.getProperty(homeSystemProp);
-        LOG.debug("PATH: (prop:{}) {}", homeSystemProp, path);
+        String path = getPath(homeConfigProp).normalize().toString();
+        LOG.debug("PATH: (config file:{}) {}", homeConfigProp, path);
         if (isBlank(path)) {
-            path = System.getenv(homeSystemEnv);
-            LOG.debug("PATH: (env:{}) {}", homeSystemEnv, path);
+            path = System.getProperty(homeSystemProp);
+            LOG.debug("PATH: (prop:{}) {}", homeSystemProp, path);
             if (isBlank(path)) {
-                path = System.getenv("user.dir");
-                LOG.debug("PATH: user.dir {}", path);
+                path = System.getenv(homeSystemEnv);
+                LOG.debug("PATH: (env:{}) {}", homeSystemEnv, path);
                 if (isBlank(path)) {
-                    path = System.getenv("HOME");
-                    LOG.debug("PATH: HOME {}", path);
+                    path = System.getenv("user.dir");
+                    LOG.debug("PATH: user.dir {}", path);
                     if (isBlank(path)) {
-                        path = Paths.get(".").normalize().toString();
-                        LOG.debug("PATH: {}", path);
+                        path = System.getenv("HOME");
+                        LOG.debug("PATH: HOME {}", path);
+                        if (isBlank(path)) {
+                            path = Paths.get(".").normalize().toString();
+                            LOG.debug("PATH: {}", path);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/drunkendev/web/settings/AppConfig.java
+++ b/src/main/java/com/drunkendev/web/settings/AppConfig.java
@@ -27,9 +27,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
+
+import static java.util.Objects.isNull;
 
 import static org.apache.commons.lang3.BooleanUtils.toBoolean;
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
@@ -154,7 +157,7 @@ public class AppConfig implements InitializingBean {
             return homeDir;
         }
 
-        String path = getPath(homeConfigProp).normalize().toString();
+        String path = getString(homeConfigProp);
         LOG.debug("PATH: (config file:{}) {}", homeConfigProp, path);
         if (isBlank(path)) {
             path = System.getProperty(homeSystemProp);

--- a/src/main/java/com/drunkendev/web/settings/AppConfig.java
+++ b/src/main/java/com/drunkendev/web/settings/AppConfig.java
@@ -181,6 +181,10 @@ public class AppConfig implements InitializingBean {
         return homeDir;
     }
 
+    public String getAppName() {
+        return appNameLc;
+    }
+
     public Path getHomePath() {
         String v = getHomeDir();
         return v == null ? null : Paths.get(v).normalize();


### PR DESCRIPTION
Howdy Brett,

I have changed the getHomeDir() method in AppConfig class slightly as it didn't work cleanly on Windows so I have introduced a config property that can deliberately set the home folder and then check for this first before falling back to checking the existing properties/env variables it currently checks.

I have also changed H2DBBackup class slightly to also look for a config property to specify the backup folder before it defaults to a backup subfolder in the home folder, I have also included the app name in the backup filename if one is set, otherwise, it defaults to the current naming convention of app-db-backup.